### PR TITLE
Correct Wikipedia link for book

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -43,7 +43,7 @@
 		<dc:source>https://catalog.hathitrust.org/Record/101879136</dc:source>
 		<meta property="se:word-count">60375</meta>
 		<meta property="se:reading-ease.flesch">83.05</meta>
-		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/The_Magic_City</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/The_Magic_City_(novel)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/e-nesbit_the-magic-city</meta>
 		<dc:creator id="author">E. Nesbit</dc:creator>
 		<meta property="file-as" refines="#author">Nesbit, E.</meta>


### PR DESCRIPTION
Original link went to disambiguation page. Updated link goes to the page for the novel itself.